### PR TITLE
Bump versions of gevent and MarkUpSafe

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,11 @@
 click==6.7
 Flask==0.12.3
-gevent==1.2.2
+gevent==20.6.2
 greenlet==0.4.13
 gunicorn==19.7.1
 itsdangerous==0.24
 Jinja2==2.10.1
-MarkupSafe==1.0
+MarkupSafe==1.1.1
 neo4j-driver==1.5.3
 python-dateutil==2.7.2
 simplejson==3.13.2


### PR DESCRIPTION
* gevent: support Python >= 3.7: https://github.com/gevent/gevent/issues/1297
* MarkUpSafe: support latest setuptools: https://github.com/pallets/markupsafe/issues/57#issuecomment-597105876